### PR TITLE
Adds a timeout to solve

### DIFF
--- a/examples/fiestel.rs
+++ b/examples/fiestel.rs
@@ -51,7 +51,7 @@ fn main() {
 
     // Print the required keys.
     // Adding a parameter for timeout in ms
-    if let Ok(result) = solver.solve(&mut z3, Some(5000)) {
+    if let Ok(result) = solver.solve_with_timeout(&mut z3, 1000) {
         println!("LK: {:x}; RK: {:x}", result[&lk], result[&rk]);
     } else {
         println!("No Solution.");

--- a/examples/fiestel.rs
+++ b/examples/fiestel.rs
@@ -50,7 +50,8 @@ fn main() {
     let _ = solver.assert(core::OpCodes::Cmp, &[rt, rt_const]);
 
     // Print the required keys.
-    if let Ok(result) = solver.solve(&mut z3) {
+    // Adding a parameter for timeout in ms
+    if let Ok(result) = solver.solve(&mut z3, Some(5000)) {
         println!("LK: {:x}; RK: {:x}", result[&lk], result[&rk]);
     } else {
         println!("No Solution.");

--- a/src/backends/backend.rs
+++ b/src/backends/backend.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt;
 
-use theories::core;
 use backends::smtlib2::SMTProc;
 
 #[derive(Clone, Debug)]
@@ -38,8 +37,6 @@ pub type SMTResult<T> = Result<T, SMTError>;
 ///  - set_option
 ///  - get_info
 ///  - set_info
-// Functions which do not really make sense for the solver currently:
-// 1. exit - The solver instance 
 pub trait SMTBackend {
     type Idx: Debug + Clone;
     type Logic: Logic;
@@ -52,11 +49,8 @@ pub trait SMTBackend {
               P: Into<<<Self as SMTBackend>::Logic as Logic>::Sorts>;
 
     fn assert<T: Into<<<Self as SMTBackend>::Logic as Logic>::Fns>>(&mut self, T, &[Self::Idx]) -> Self::Idx;
-    // Adding a way to add a timeout to check_sat and solve methods.
-    // If no value is provided it will default to indefinite wait.
-    fn check_sat<S: SMTProc>(&mut self, &mut S, Option<u64>) -> SMTResult<bool>;
-    fn solve<S: SMTProc>(&mut self, &mut S, Option<u64>) -> SMTResult<HashMap<Self::Idx, u64>>;
-
+    fn check_sat<S: SMTProc>(&mut self, &mut S) -> SMTResult<bool>;
+    fn solve<S: SMTProc>(&mut self, &mut S) -> SMTResult<HashMap<Self::Idx, u64>>;
 }
 
 pub trait Logic: fmt::Display + Clone + Copy {

--- a/src/backends/backend.rs
+++ b/src/backends/backend.rs
@@ -10,6 +10,7 @@ use backends::smtlib2::SMTProc;
 
 #[derive(Clone, Debug)]
 pub enum SMTError {
+    Timeout,
     Undefined,
     Unsat,
     AssertionError(String),
@@ -37,7 +38,8 @@ pub type SMTResult<T> = Result<T, SMTError>;
 ///  - set_option
 ///  - get_info
 ///  - set_info
-///  - exit
+// Functions which do not really make sense for the solver currently:
+// 1. exit - The solver instance 
 pub trait SMTBackend {
     type Idx: Debug + Clone;
     type Logic: Logic;
@@ -50,8 +52,11 @@ pub trait SMTBackend {
               P: Into<<<Self as SMTBackend>::Logic as Logic>::Sorts>;
 
     fn assert<T: Into<<<Self as SMTBackend>::Logic as Logic>::Fns>>(&mut self, T, &[Self::Idx]) -> Self::Idx;
-    fn check_sat<S: SMTProc>(&mut self, &mut S) -> bool;
-    fn solve<S: SMTProc>(&mut self, &mut S) -> SMTResult<HashMap<Self::Idx, u64>>;
+    // Adding a way to add a timeout to check_sat and solve methods.
+    // If no value is provided it will default to indefinite wait.
+    fn check_sat<S: SMTProc>(&mut self, &mut S, Option<u64>) -> SMTResult<bool>;
+    fn solve<S: SMTProc>(&mut self, &mut S, Option<u64>) -> SMTResult<HashMap<Self::Idx, u64>>;
+
 }
 
 pub trait Logic: fmt::Display + Clone + Copy {

--- a/src/backends/backend.rs
+++ b/src/backends/backend.rs
@@ -49,7 +49,7 @@ pub trait SMTBackend {
               P: Into<<<Self as SMTBackend>::Logic as Logic>::Sorts>;
 
     fn assert<T: Into<<<Self as SMTBackend>::Logic as Logic>::Fns>>(&mut self, T, &[Self::Idx]) -> Self::Idx;
-    fn check_sat<S: SMTProc>(&mut self, &mut S) -> SMTResult<bool>;
+    fn check_sat<S: SMTProc>(&mut self, &mut S) -> bool;
     fn solve<S: SMTProc>(&mut self, &mut S) -> SMTResult<HashMap<Self::Idx, u64>>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! Crate that allows rust programs to interact with SMT (Satisfiability Modulo Theory) solvers.
 
+#![allow(non_camel_case_types)]
 extern crate petgraph;
 extern crate regex;
 

--- a/src/logics/qf_abv.rs
+++ b/src/logics/qf_abv.rs
@@ -1,4 +1,3 @@
-use std::fmt::{Display, Debug};
 use std::fmt;
 
 use theories::{array_ex, bitvec, core};

--- a/src/logics/qf_aufbv.rs
+++ b/src/logics/qf_aufbv.rs
@@ -1,4 +1,3 @@
-use std::fmt::{Display, Debug};
 use std::fmt;
 
 use theories::{array_ex, bitvec, core};

--- a/src/logics/utils.rs
+++ b/src/logics/utils.rs
@@ -1,10 +1,5 @@
 //! Defines macros to build Logics on top of theories.
 
-use std::convert::Into;
-use std::fmt;
-
-use backends::backend::{Logic, SMTNode};
-
 #[macro_export]
 macro_rules! define_sorts_for_logic {
     ($logic: ident, $($variant: ident -> $sort: ty),*) => {

--- a/src/theories/bitvec.rs
+++ b/src/theories/bitvec.rs
@@ -1,6 +1,5 @@
 //! Defines basic operations defined under FixedSizeBitVectors theory in SMTLIB2.
 
-use std::fmt::Debug;
 use std::fmt;
 
 use backends::backend::SMTNode;

--- a/src/theories/core.rs
+++ b/src/theories/core.rs
@@ -1,7 +1,6 @@
 //! Defines basic operation defined under Core theory in SMTLIB2.
 
 use std::fmt;
-use std::fmt::Debug;
 
 use backends::backend::SMTNode;
 

--- a/src/theories/integer.rs
+++ b/src/theories/integer.rs
@@ -1,10 +1,7 @@
 //! Defines basic operations defined under Int theory in SMTLIB2.
 
 use std::fmt;
-use std::fmt::Debug;
 
-#[macro_use]
-use theories::utils;
 use backends::backend::SMTNode;
 
 #[derive(Clone, Debug)]

--- a/src/theories/real.rs
+++ b/src/theories/real.rs
@@ -2,8 +2,6 @@
 
 use std::fmt;
 
-#[macro_use]
-use theories::utils;
 use backends::backend::SMTNode;
 
 #[derive(Clone, Debug)]

--- a/src/theories/real_ints.rs
+++ b/src/theories/real_ints.rs
@@ -2,8 +2,6 @@
 
 use std::fmt;
 
-#[macro_use]
-use theories::utils;
 use backends::backend::SMTNode;
 
 #[derive(Clone, Debug)]
@@ -62,6 +60,6 @@ impl fmt::Display for Sorts {
             Sorts::Real => "Real",
             Sorts::Int => "Int"
         };
-        write!(f, "{}", "s")
+        write!(f, "{}", s)
     }
 }

--- a/src/theories/utils.rs
+++ b/src/theories/utils.rs
@@ -1,7 +1,5 @@
 //! Macro helpers for defining theories
 
-use backends::backend::SMTNode;
-
 #[macro_export]
 macro_rules! impl_smt_node {
     ($fns: ty, define vars [$($variant: pat),*], define consts [$($c: pat),*]) => {


### PR DESCRIPTION
This PR aims to achieve the following:

* Uses channels to add a timeout functionality for the read() function of the SMTProcess. This enables us to wait until we receive a signal on the channel before the timeout. We add a new error type `SMTError::Timeout` to enable the user to check if the solver timed out on the current set of constraints.

* `solver.solve_with_timeout(smt_proc, time_in_milliseconds)` now allows us to provide an argument for time in ms. This has not been added to the SMTBackend trait and can be added in future versions. Also added a similar `check_sat_with_timeout`. This now makes `read()` take a Option<u64> argument for the timeout period.

* Also fixes a bunch of compiler warnings.

* Fixes an error in `real_insts.rs` where the string "s" was being written instead of the variable.