### PR TITLE
Feature addition and issue fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
       - libdw-dev
       - binutils-dev
       - wget
+      - bzip2
 
 matrix:
   fast_finish: true
@@ -42,6 +43,12 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget "https://github.com/Z3Prover/z3/releases/download/z3-4.4.1/z3-4.4.1-x64-ubuntu-14.04.zip" ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then unzip z3-4.4.1-x64-ubuntu-14.04.zip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=$PATH:./z3-4.4.1-x64-ubuntu-14.04/bin/ ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget "http://fmv.jku.at/boolector/boolector-2.4.1-with-lingeling-bbc.tar.bz2" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then bzip2 -d boolector-2.4.1-with-lingeling-bbc.tar.bz2 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar -xvf boolector-2.4.1-with-lingeling-bbc.tar ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make -C boolector-2.4.1-with-lingeling-bbc ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=$PATH:./boolector-2.4.1-with-lingeling-bbc/boolector/bin/ ; fi
+
 env:
   global:
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""

--- a/src/backends/backend.rs
+++ b/src/backends/backend.rs
@@ -44,12 +44,13 @@ pub trait SMTBackend {
 
     fn set_logic<S: SMTProc>(&mut self, &mut S);
     //fn declare_fun<T: AsRef<str>>(&mut self, Option<T>, Option<Vec<Type>>, Type) -> Self::Idx;
-
+    
     fn new_var<T, P>(&mut self, Option<T>, P) -> Self::Idx
         where T: AsRef<str>,
               P: Into<<<Self as SMTBackend>::Logic as Logic>::Sorts>;
 
     fn assert<T: Into<<<Self as SMTBackend>::Logic as Logic>::Fns>>(&mut self, T, &[Self::Idx]) -> Self::Idx;
+    fn simplify<S: SMTProc>(&mut self, &mut S, Self::Idx) -> SMTResult<u64>;
     fn check_sat<S: SMTProc>(&mut self, &mut S) -> bool;
     fn solve<S: SMTProc>(&mut self, &mut S) -> SMTResult<HashMap<Self::Idx, u64>>;
 }

--- a/src/backends/boolector.rs
+++ b/src/backends/boolector.rs
@@ -1,0 +1,57 @@
+//! Struct and methods to interact with the boolector solver.
+
+use backends::smtlib2::SMTProc;
+use std::process::{Child, Command, Stdio};
+
+#[derive(Default)]
+pub struct Boolector {
+    fd: Option<Child>,
+}
+
+// Add boolector binary path to $PATH
+impl SMTProc for Boolector {
+    fn init(&mut self) {
+        let (cmd, args) = ("boolector", &["-m", "--smt2-model", "--smt2"]);
+        let child = Command::new(cmd)
+                        .args(args)
+                        .stdout(Stdio::piped())
+                        .stdin(Stdio::piped())
+                        .stderr(Stdio::piped())
+                        .spawn()
+                        .expect("Failed to spawn process");
+        self.fd = Some(child);
+    }
+
+    fn pipe<'a>(&'a mut self) -> &'a mut Child {
+        if self.fd.is_none() {
+            self.init();
+        }
+        self.fd.as_mut().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use backends::backend::*;
+    use backends::smtlib2::*;
+    use super::*;
+    use theories::bitvec;
+    use theories::{core, integer};
+    use logics::{lia, qf_bv};
+
+    #[test]
+    fn test_bl_bitvec() {
+        let mut bl: Boolector = Default::default();
+        let mut solver = SMTLib2::new(Some(qf_bv::QF_BV));
+        let x = solver.new_var(Some("X"), bitvec::Sorts::BitVector(32));
+        let c = solver.new_const(bitvec::OpCodes::Const(10, 32));
+        let c8 = solver.new_const(bitvec::OpCodes::Const(8, 32));
+        let y = solver.new_var(Some("Y"), bitvec::Sorts::BitVector(32));
+        solver.assert(core::OpCodes::Cmp, &[x, c]);
+        let x_xor_y = solver.assert(bitvec::OpCodes::BvXor, &[x, y]);
+        solver.assert(core::OpCodes::Cmp, &[x_xor_y, c8]);
+        let result = solver.solve(&mut bl).unwrap();
+        assert_eq!(result[&x], 10);
+        assert_eq!(result[&y], 2);
+    }
+}

--- a/src/backends/smtlib2.rs
+++ b/src/backends/smtlib2.rs
@@ -43,6 +43,11 @@ pub trait SMTProc {
         Ok(())
     }
 
+    // Helper function to insert a process specific read if needed 
+    // at places where buffering is an issue.
+    fn proc_specific_read(&mut self) {
+    }
+
     fn read(&mut self) -> String {
         // XXX: This read may block indefinitely if there is nothing on the pipe to be
         // read. To prevent this we need a timeout mechanism after which we should
@@ -95,6 +100,10 @@ impl<L: Logic> SMTLib2<L> {
             idx_map: HashMap::new(),
         };
         solver
+    }
+
+    pub fn get_node_info(&self, ni: NodeIndex) -> &L::Fns {
+        self.gr.node_weight(ni).unwrap()
     }
 
     // Recursive function that builds up the assertion string from the tree.
@@ -215,26 +224,22 @@ impl<L: Logic> SMTBackend for SMTLib2<L> {
         }
 
         smt_proc.write("(get-model)\n".to_owned());
-        // XXX: For some reason we need two reads here in order to get the result from
-        // the SMT solver. Need to look into the reason for this. This might stop
-        // working in the
-        // future.
-        let _ = smt_proc.read();
+        smt_proc.proc_specific_read();
+        
         let read_result = smt_proc.read();
 
-        // Example of result from the solver:
+        // Example of result from the solver(Could very well vary):
         // (model
-        //  (define-fun y () Int
-        //    9)
-        //  (define-fun x () Int
-        //    10)
+        //   (define-fun y () Int 9)
+        //   (define-fun x () Int 10)
         // )
-        let re = Regex::new(r"\s+\(define-fun (?P<var>[0-9a-zA-Z_]+) \(\) [(]?[ _a-zA-Z0-9]+[)]?\n\s+(?P<val>([0-9]+|#x[0-9a-f]+|#b[01]+))")
+        let re = Regex::new(r"\s+\(define-fun (?P<var>[0-9a-zA-Z_]+) \(\) [(]?[ _a-zA-Z0-9]+[)]?\n??\s+(?P<val>(-?[0-9]+|#x[0-9a-f]+|#b[01]+))")
                      .unwrap();
         for caps in re.captures_iter(&read_result) {
             // Here the caps.name("val") can be a hex value, or a binary value or a decimal
             // value. We need to parse the output to a u64 accordingly.
             let val_str = caps.name("val").unwrap().as_str();
+
             let val = if val_str.len() > 2 && &val_str[0..2] == "#x" {
                           u64::from_str_radix(&val_str[2..], 16)
                       } else if val_str.len() > 2 && &val_str[0..2] == "#b" {

--- a/src/backends/z3.rs
+++ b/src/backends/z3.rs
@@ -27,6 +27,11 @@ impl SMTProc for Z3 {
         }
         self.fd.as_mut().unwrap()
     }
+
+    // Because of the z3 buffering issue.
+    fn proc_specific_read(&mut self) {
+        self.read();
+    }
 }
 
 #[cfg(test)]
@@ -48,8 +53,8 @@ mod test {
         solver.assert(core::OpCodes::Cmp, &[x, c]);
         solver.assert(integer::OpCodes::Gt, &[x, y]);
         let result = solver.solve(&mut z3).unwrap();
-        assert_eq!(result[&x], 10);
         assert_eq!(result[&y], 9);
+        assert_eq!(result[&x], 10);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,4 +25,5 @@ pub mod backends {
     pub mod backend;
     pub mod smtlib2;
     pub mod z3;
+    pub mod boolector;
 }

--- a/src/logics/qf_abv.rs
+++ b/src/logics/qf_abv.rs
@@ -43,7 +43,6 @@ define_logic!(QF_ABV,
               }
               );
 
-
 // Helper methods that help in contruction of array and bitvector types.
 pub fn array_sort<T: Into<QF_ABV_Sorts>, P: Into<QF_ABV_Sorts>>(idx: T, data: P) -> QF_ABV_Sorts {
     QF_ABV_Sorts::ArrayEx(array_ex::Sorts::new(idx.into(), data.into()))


### PR DESCRIPTION
Aims to achieve the following:

* Adds support for Boolector backend. Boolector is a SMT Solver which won 3 out of 6 tracks in the SMT Contest 2016. This is specifically interesting to us since it is observed to be extremely fast for Quantifier Free BitVector(QF_BV) logic. This can be helpful in getting faster results for rune. Also, it supports SMTLibv2 format for input so it becomes all the more easier to integrate. This requires you to have the boolector binary in your PATH variable. The source for the library can be found [here](http://fmv.jku.at/boolector/boolector-2.4.1-with-lingeling-bbc.tar.bz2).

* Adds a dummy function proc_specific_read(), due to the z3 buffering issue.

* Adds function get_node_info() for the solver instance which exposes an API to get node data so that it becomes a bit easier for debugging in other libraries(such as for example, once again, rune/radeco).

Tests failing since we don't have boolector installed.